### PR TITLE
chore: bump to nightly-2025-05-17

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2025-04-03
+          toolchain: nightly-2025-05-17
           components: rustc-dev, llvm-tools-preview
           override: true
 
@@ -108,7 +108,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2025-04-03
+          toolchain: nightly-2025-05-17
           components: rustc-dev, llvm-tools-preview, clippy
           override: true
 

--- a/amplifier-lints/cosmwasm_addr_in_msg_struct/src/lib.rs
+++ b/amplifier-lints/cosmwasm_addr_in_msg_struct/src/lib.rs
@@ -17,7 +17,7 @@ dylint_linting::declare_late_lint! {
 impl<'tcx> LateLintPass<'tcx> for CosmwasmAddrInMsgStruct {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         match item.kind {
-            ItemKind::Struct(ident, variant_data, _) => {
+            ItemKind::Struct(ident, variant_data, _generics) => {
                 if ident.name.as_str() != "ExecuteMsg"
                     && ident.name.as_str() != "InstantiateMsg"
                     && ident.name.as_str() != "QueryMsg"
@@ -34,7 +34,7 @@ impl<'tcx> LateLintPass<'tcx> for CosmwasmAddrInMsgStruct {
                     });
                 });
             }
-            ItemKind::Enum(ident, enum_def, _) => {
+            ItemKind::Enum(ident, enum_def, _generics) => {
                 if ident.name.as_str() != "ExecuteMsg"
                     && ident.name.as_str() != "InstantiateMsg"
                     && ident.name.as_str() != "QueryMsg"

--- a/amplifier-lints/cosmwasm_addr_in_msg_struct/src/lib.rs
+++ b/amplifier-lints/cosmwasm_addr_in_msg_struct/src/lib.rs
@@ -62,15 +62,15 @@ impl<'tcx> LateLintPass<'tcx> for CosmwasmAddrInMsgStruct {
 
 fn check_cosmwasm_addr_in_field(cx: &LateContext, fields: &[FieldDef]) -> bool {
     for field in fields {
-        if let TyKind::Path(QPath::Resolved(_, path)) = field.ty.kind {
-            if let Res::Def(_, def_id) = path.res {
-                let path_str = cx.tcx.def_path_str(def_id);
-                if path_str != "cosmwasm_std::Addr" {
-                    continue;
-                }
-
-                return true;
+        if let TyKind::Path(QPath::Resolved(_, path)) = field.ty.kind
+            && let Res::Def(_, def_id) = path.res
+        {
+            let path_str = cx.tcx.def_path_str(def_id);
+            if path_str != "cosmwasm_std::Addr" {
+                continue;
             }
+
+            return true;
         }
     }
     false

--- a/amplifier-lints/execute_without_explicit_permissions/src/lib.rs
+++ b/amplifier-lints/execute_without_explicit_permissions/src/lib.rs
@@ -8,7 +8,7 @@ extern crate rustc_span;
 use rustc_hir::intravisit::{FnKind, Visitor, walk_body, walk_expr};
 use rustc_hir::{Body, ExprKind, FnDecl, PatKind, QPath};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_span::{FileName, RealFileName, Span, def_id::LocalDefId, symbol::Ident};
+use rustc_span::{FileName, Span, def_id::LocalDefId, symbol::Ident};
 
 dylint_linting::declare_late_lint! {
     pub EXECUTE_WITHOUT_EXPLICIT_PERMISSIONS,
@@ -53,7 +53,8 @@ fn is_contract_rs_execute(cx: &LateContext<'_>, span: Span) -> bool {
     let source_map = cx.tcx.sess.source_map();
     let file_name = source_map.span_to_filename(span);
 
-    if let FileName::Real(RealFileName::LocalPath(path)) = file_name
+    if let FileName::Real(real_name) = file_name
+        && let Some(path) = real_name.local_path()
         && path.ends_with("contract.rs")
     {
         return true;

--- a/amplifier-lints/msg_without_explicit_permissions/src/lib.rs
+++ b/amplifier-lints/msg_without_explicit_permissions/src/lib.rs
@@ -9,7 +9,7 @@ extern crate rustc_span;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::AssocKind;
-use rustc_span::symbol::Ident;
+use rustc_span::Symbol;
 
 dylint_linting::declare_late_lint! {
     pub MSG_WITHOUT_EXPLICIT_PERMISSIONS,
@@ -29,15 +29,11 @@ impl<'tcx> LateLintPass<'tcx> for MsgWithoutExplicitPermissions {
 
             for impl_id in impls {
                 let associated_items = cx.tcx.associated_items(impl_id);
-                if associated_items
-                    .find_by_name_and_kind(
-                        cx.tcx,
-                        Ident::from_str("ensure_permissions"),
-                        AssocKind::Fn,
-                        item.owner_id.to_def_id(),
-                    )
-                    .is_some()
-                {
+                let has_ensure_permissions = associated_items.in_definition_order().any(|assoc| {
+                    matches!(assoc.kind, AssocKind::Fn { .. })
+                        && assoc.name() == Symbol::intern("ensure_permissions")
+                });
+                if has_ensure_permissions {
                     return;
                 }
             }

--- a/amplifier-lints/ref_opt_type/src/lib.rs
+++ b/amplifier-lints/ref_opt_type/src/lib.rs
@@ -25,7 +25,7 @@ impl<'tcx> LateLintPass<'tcx> for RefOptType {
             let inner_snippet = get_snippet_or_default(cx, path);
 
             cx.span_lint(REF_OPT_TYPE, ty.span, |diag| {
-                diag.primary_message(format!("use `Option<&{}>` instead", inner_snippet));
+                diag.primary_message(format!("use `Option<&{inner_snippet}>` instead"));
             });
         }
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-04-03"
+channel = "nightly-2025-05-17"
 components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION
Dylint was running into issues with an indirect dependency `zmij` in [this PR](https://github.com/axelarnetwork/axelar-amplifier/pull/1140). Updating should fix the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the project to the newer Rust nightly and aligns internal lints with updated rustc APIs.
> 
> - Bumps toolchain in `rust-toolchain` and GitHub Actions (`basic.yaml`) to `nightly-2025-05-17`; updates fmt/clippy steps accordingly
> - Adjusts lint crates for compatibility: adds `_generics` in `ItemKind` matches, switches `FileName` handling to `local_path()`, replaces `Ident` lookup with `Symbol` + `in_definition_order()`, consolidates `let`-chain pattern matches, and minor format string update
> - CI tasks remain the same (tests, fmt, sort, clippy)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 152a58f9b4c7bf30d9bc19ddcb30caf253657da4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->